### PR TITLE
fix: find file if an another instance of soffice is running

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,11 @@ exports.convert = (document, format, filter, callback) => {
             return exec(command, callback);
         }],
         loadDestination: ['convert', (results, callback) =>
-            fs.readFile(path.join(results.tempDir, `source.${format}`), (err, destination) => {
-                if (err) {
-                    return callback(err);
-                }
-
-                return callback(null, destination);
-            })],
+            async.retry({
+                times: 3,
+                interval: 200
+            }, (callback) => fs.readFile(path.join(results.tempDir, `source.${format}`), callback), callback)
+        ]
     }, (err, res) => {
         temp.cleanup();
 

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -1,6 +1,7 @@
 var _jest = require('jest'),
     _fs = require('fs'),
     _path = require('path'),
+    { exec } = require('child_process'),
     convert = require('../index').convert;
 
 describe('convert', () => {
@@ -18,5 +19,16 @@ describe('convert', () => {
     it('should convert a word document to text',  (done) => {
         const docx = _fs.readFileSync(_path.join(__dirname, '/resources/hello.docx'));
         convert(docx, 'txt', undefined, expectHello(done));
+    });
+
+
+    it('if an another instance of soffice exists, should convert a word document to text',  (done) => {
+        exec("soffice  --headless")
+        // this command create an instance of soffice. This instance will get a failure "Error: source file could not be loaded"
+        // but only after we ask a new convert. So this is enought to reproduce fail when an another instance is open
+        setTimeout(()=> {
+            const docx = _fs.readFileSync(_path.join(__dirname, '/resources/hello.docx'));
+            convert(docx, 'txt', undefined, expectHello(done));
+        }, 100);
     });
 });


### PR DESCRIPTION
Hi,

**It's a fix for the following problem :** 
If you run an another instance of soffice, this project throw an error `Error converting file: Error: ENOENT: no such file or directory, open '/tmp/libreofficeConvert2020127-10458-1aopsc8.rdtel/source.pdf'`

**How reproduce on master :** 
Just open Libre Office GUI and run test of this project.