### PR TITLE
Enabled parallel invocations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const fs = require('fs');
-const temp = require('temp').track();
 const path = require('path');
 const async = require('async');
+const tmp = require('tmp');
 const { exec } = require('child_process');
 
 exports.convert = (document, format, filter, callback) => {
+    const tempDir = tmp.dirSync({prefix: 'libreofficeConvert_', unsafeCleanup: true});
     return async.auto({
         soffice: (callback) => {
             let paths = [];
@@ -37,14 +38,13 @@ exports.convert = (document, format, filter, callback) => {
                 }
             );
         },
-        tempDir: callback => temp.mkdir('libreofficeConvert', callback),
-        saveSource: ['tempDir', (results, callback) => fs.writeFile(path.join(results.tempDir, 'source'), document, callback)],
+        saveSource: callback => fs.writeFile(path.join(tempDir.name, 'source'), document, callback),
         convert: ['soffice', 'saveSource', (results, callback) => {
             let command = `${results.soffice} --headless --convert-to ${format}`;
             if (filter !== undefined) {
                 command += `:"${filter}"`;
             }
-            command += ` --outdir ${results.tempDir} ${path.join(results.tempDir, 'source')}`;
+            command += ` --outdir ${tempDir.name} ${path.join(tempDir.name, 'source')}`;
 
             return exec(command, callback);
         }],
@@ -52,10 +52,10 @@ exports.convert = (document, format, filter, callback) => {
             async.retry({
                 times: 3,
                 interval: 200
-            }, (callback) => fs.readFile(path.join(results.tempDir, `source.${format}`), callback), callback)
+            }, (callback) => fs.readFile(path.join(tempDir.name, `source.${format}`), callback), callback)
         ]
     }, (err, res) => {
-        temp.cleanup();
+        tempDir.removeCallback();
 
         if (err) {
             return callback(err);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.6.2",
-    "temp": "^0.9.0"
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "jest": "^24.7.1"


### PR DESCRIPTION
The problem with parallel invocations was that the `temp` package cleanup was global, which caused it to remove dirs and files necessary for other concurrent invocations. Switched to use another very popular package -- `tmp` -- which has a more controllable cleanup.

One note about the code, since I must have access to the tmp dir object for cleanup in the final callback, I created the tmp dir outside of the `async.task` pile.