### PR TITLE
Check bin file in /snap/bin folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const convertWithOptions = (document, format, filter, options, callback) => {
             switch (process.platform) {
                 case 'darwin': paths = ['/Applications/LibreOffice.app/Contents/MacOS/soffice'];
                     break;
-                case 'linux': paths = ['/usr/bin/libreoffice', '/usr/bin/soffice'];
+                case 'linux': paths = ['/usr/bin/libreoffice', '/usr/bin/soffice', '/snap/bin/libreoffice'];
                     break;
                 case 'win32': paths = [
                     path.join(process.env['PROGRAMFILES(X86)'], 'LIBREO~1/program/soffice.exe'),


### PR DESCRIPTION
When install libreoffice via command `sudo snap install libreoffice`, the soffice binary is located at `/snap/bin/libreoffice` - [https://www.libreoffice.org/download/snap/](https://www.libreoffice.org/download/snap/)