### PR TITLE
fix convert to "html:HTML:EmbedImages" bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const convertWithOptions = (document, format, filter, options, callback) => {
             async.retry({
                 times: asyncOptions.times || 3,
                 interval: asyncOptions.interval || 200
-            }, (callback) => fs.readFile(path.join(tempDir.name, `source.${format}`), callback), callback)
+            }, (callback) => fs.readFile(path.join(tempDir.name, `source.${format.split(":")[0]}`), callback), callback)
         ]
     }, (err, res) => {
         tempDir.removeCallback();


### PR DESCRIPTION
When converting a document containing images to html, need set parameter format to "html:HTML:EmbedImages", but will throw an error: no such file or directory.