### PR TITLE
docs: improve language for clarity & spelling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,33 +1,33 @@
-# libreoffice-convert #
+# libreoffice-convert
 
 A simple and fast node.js module for converting office documents to different formats.
 
-## Dependency ##
+## Dependency
 
 Please install libreoffice in /Applications (Mac), with your favorite package manager (Linux), or with the msi (Windows).
 
+## Usage example
 
-## Usage example ##
 ```javascript
 const libre = require('libreoffice-convert');
 
 const path = require('path');
 const fs = require('fs');
 
-const extend = '.pdf'
-const enterPath = path.join(__dirname, '/resources/example.docx');
-const outputPath = path.join(__dirname, `/resources/example${extend}`);
+const ext = '.pdf'
+const inputPath = path.join(__dirname, '/resources/example.docx');
+const outputPath = path.join(__dirname, `/resources/example${ext}`);
 
 // Read file
-const file = fs.readFileSync(enterPath);
-// Convert it to pdf format with undefined filter (see Libreoffice doc about filter)
-libre.convert(file, extend, undefined, (err, done) => {
+const docxBuf = fs.readFileSync(inputPath);
+
+// Convert it to pdf format with undefined filter (see Libreoffice docs about filter)
+libre.convert(docxBuf, ext, undefined, (err, pdfBuf) => {
     if (err) {
       console.log(`Error converting file: ${err}`);
     }
     
     // Here in done you have pdf file which you can save or transfer in another stream
-    fs.writeFileSync(outputPath, done);
+    fs.writeFileSync(outputPath, pdfBuf);
 });
 ```
-


### PR DESCRIPTION
- use nodejs naming conventions to distinguish between buffers, strings, streams, etc
- use correct spelling `ext` (as in extension) rather than `extend`
- use more conventional English terms such as `inputPath` rather than `enterPath`
- use standard markdown headers

# View Preview

https://github.com/coolaj86/libreoffice-convert/blob/patch-1/Readme.md