### PR TITLE
Converting paths to a file, fixing #32

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 const async = require('async');
 const tmp = require('tmp');
 const { execFile } = require('child_process');
@@ -43,7 +44,7 @@ const convertWithOptions = (document, format, filter, options, callback) => {
         },
         saveSource: callback => fs.writeFile(path.join(tempDir.name, 'source'), document, callback),
         convert: ['soffice', 'saveSource', (results, callback) => {
-            let command = `-env:UserInstallation=file://${installDir.name} --headless --convert-to ${format}`;
+            let command = `-env:UserInstallation=${url.pathToFileURL(installDir.name)} --headless --convert-to ${format}`;
             if (filter !== undefined) {
                 command += `:"${filter}"`;
             }


### PR DESCRIPTION
this fixes the bootstrap.ini problem described in #32. I am not able to test on other platforms, but the url-helper should work across systems as far as I know.