### PR TITLE
Fix: problem on conversion in Windows 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,12 @@ const convertWithOptions = (document, format, filter, options, callback) => {
         },
         saveSource: callback => fs.writeFile(path.join(tempDir.name, 'source'), document, callback),
         convert: ['soffice', 'saveSource', (results, callback) => {
-            let command = `-env:UserInstallation=${url.pathToFileURL(installDir.name)} --headless --convert-to ${format}`;
+            let command = ''
+            if(process.platform == 'win32') {
+                command = `${url.pathToFileURL(installDir.name)} --headless --convert-to ${format}`;
+            } else {
+                command = `-env:UserInstallation=${url.pathToFileURL(installDir.name)} --headless --convert-to ${format}`;
+            }
             if (filter !== undefined) {
                 command += `:"${filter}"`;
             }


### PR DESCRIPTION
I fixed a problem in a conversion on windows 10, I got an error when trying to convert a `docx` file to `pdf`, and when searching I saw several similar problems where the fix was just to remove `-env:UserInstallation` directly in node_modules, so I decided to request this pull request.