### PR TITLE
specify custom path for soffice binaries

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare module "libreoffice-convert" {
     options: {
       tmpOptions?: Record<string | number | symbol, unknown>;
       asyncOptions?: { times?: number; interval?: number };
+      sofficeBinaryPaths?: string[];
     },
     callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void
   ): void;

--- a/index.js
+++ b/index.js
@@ -14,13 +14,14 @@ const convertWithOptions = (document, format, filter, options, callback) => {
     const installDir = tmp.dirSync({prefix: 'soffice', unsafeCleanup: true, ...tmpOptions});
     return async.auto({
         soffice: (callback) => {
-            let paths = [];
+            let paths = (options || {}).sofficeBinaryPaths ?? [];
             switch (process.platform) {
-                case 'darwin': paths = ['/Applications/LibreOffice.app/Contents/MacOS/soffice'];
+                case 'darwin': paths = [...paths, '/Applications/LibreOffice.app/Contents/MacOS/soffice'];
                     break;
-                case 'linux': paths = ['/usr/bin/libreoffice', '/usr/bin/soffice', '/snap/bin/libreoffice'];
+                case 'linux': paths = [...paths, '/usr/bin/libreoffice', '/usr/bin/soffice', '/snap/bin/libreoffice'];
                     break;
                 case 'win32': paths = [
+                    ...paths,
                     path.join(process.env['PROGRAMFILES(X86)'], 'LIBREO~1/program/soffice.exe'),
                     path.join(process.env['PROGRAMFILES(X86)'], 'LibreOffice/program/soffice.exe'),
                     path.join(process.env.PROGRAMFILES, 'LibreOffice/program/soffice.exe'),


### PR DESCRIPTION
This PR aims to resolve https://github.com/elwerene/libreoffice-convert/issues/49, https://github.com/elwerene/libreoffice-convert/issues/60.

Now, users can add a custom path to the soffice binary. This is particularly useful while using this package in deployments, eg. Heroku deployment. 

I have extended the options object to add `sofficeBinaryPaths` as suggested [here](https://github.com/elwerene/libreoffice-convert/issues/49#issuecomment-733071890). The users can now specify the path to soffice binary depending on where the soffice binaries are installed.

