### PR TITLE
Fix support for whitespaces in filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ const convertWithOptions = (document, format, filter, options, callback) => {
             args.push(`-env:UserInstallation=${url.pathToFileURL(installDir.name)}`);
             args.push('--headless');
             args.push('--convert-to');
-            args.push(formatParam);
+            args.push(fmt);
             args.push('--outdir');
             args.push(tempDir.name);
             args.push(path.join(tempDir.name, 'source'));

--- a/index.js
+++ b/index.js
@@ -45,10 +45,8 @@ const convertWithOptions = (document, format, filter, options, callback) => {
         },
         saveSource: callback => fs.writeFile(path.join(tempDir.name, 'source'), document, callback),
         convert: ['soffice', 'saveSource', (results, callback) => {
-            let command = `-env:UserInstallation=${url.pathToFileURL(installDir.name)} --headless --convert-to ${format}`;
-            if (filter !== undefined) {
-                command += `:"${filter}"`;
-            }
+            let fmt = !(filter ?? "").includes(" ") ? `${format}:${filter}` : `"${format}:${filter}"`;
+            let command = `-env:UserInstallation=${url.pathToFileURL(installDir.name)} --headless --convert-to ${fmt}`;
             command += ` --outdir ${tempDir.name} ${path.join(tempDir.name, 'source')}`;
             const args = command.split(' ');
             return execFile(results.soffice, args, callback);

--- a/index.js
+++ b/index.js
@@ -48,10 +48,12 @@ const convertWithOptions = (document, format, filter, options, callback) => {
             let fmt = !(filter ?? "").includes(" ") ? `${format}:${filter}` : `"${format}:${filter}"`;
             let args = [];
             args.push(`-env:UserInstallation=${url.pathToFileURL(installDir.name)}`);
-            args.push(`--headless`);
-            args.push(`--convert-to ${fmt}`);
-            args.push(`--outdir ${tempDir.name}`);
-            args.push(`${path.join(tempDir.name, 'source')}`);
+            args.push('--headless');
+            args.push('--convert-to');
+            args.push(formatParam);
+            args.push('--outdir');
+            args.push(tempDir.name);
+            args.push(path.join(tempDir.name, 'source'));
             return execFile(results.soffice, args, callback);
         }],
         loadDestination: ['convert', (results, callback) =>

--- a/index.js
+++ b/index.js
@@ -46,9 +46,12 @@ const convertWithOptions = (document, format, filter, options, callback) => {
         saveSource: callback => fs.writeFile(path.join(tempDir.name, 'source'), document, callback),
         convert: ['soffice', 'saveSource', (results, callback) => {
             let fmt = !(filter ?? "").includes(" ") ? `${format}:${filter}` : `"${format}:${filter}"`;
-            let command = `-env:UserInstallation=${url.pathToFileURL(installDir.name)} --headless --convert-to ${fmt}`;
-            command += ` --outdir ${tempDir.name} ${path.join(tempDir.name, 'source')}`;
-            const args = command.split(' ');
+            let args = [];
+            args.push(`-env:UserInstallation=${url.pathToFileURL(installDir.name)}`);
+            args.push(`--headless`);
+            args.push(`--convert-to ${fmt}`);
+            args.push(`--outdir ${tempDir.name}`);
+            args.push(`${path.join(tempDir.name, 'source')}`);
             return execFile(results.soffice, args, callback);
         }],
         loadDestination: ['convert', (results, callback) =>

--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ const convertWithOptions = (document, format, filter, options, callback) => {
         },
         saveSource: callback => fs.writeFile(path.join(tempDir.name, 'source'), document, callback),
         convert: ['soffice', 'saveSource', (results, callback) => {
-            let fmt = !(filter ?? "").includes(" ") ? `${format}:${filter}` : `"${format}:${filter}"`;
+            let filterParam = filter?.length ? `:${filter}` : "";
+            let fmt = !(filter ?? "").includes(" ") ? `${format}${filterParam}` : `"${format}${filterParam}"`;
             let args = [];
             args.push(`-env:UserInstallation=${url.pathToFileURL(installDir.name)}`);
             args.push('--headless');


### PR DESCRIPTION
Fixes using filter names have spaces in their name which breaks both argument passing to soffice and argument splitting before invocation.

Example would be using:
let format='htm';
let filter='HTML (StarWriter)';