### PR TITLE
Added support to intake fileName in convertWithOptions in order to fix footer issue

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare module "libreoffice-convert" {
       tmpOptions?: Record<string | number | symbol, unknown>;
       asyncOptions?: { times?: number; interval?: number };
       sofficeBinaryPaths?: string[];
+      fileName?: string;
     },
     callback: (err: NodeJS.ErrnoException | null, data: Buffer) => void
   ): void;


### PR DESCRIPTION
When attempting to convert a DOCX file to PDF, the footer text does not convert correctly. Specifically, when there is a footer in the DOCX file (in my case, it contained the document name), the library defaults it to "source", whereas LibreOffice inserts the file name instead. To address this issue, I introduced a fileName parameter in convertWithOptions. If provided, this parameter overrides the default "source" string.

Issue link: https://github.com/elwerene/libreoffice-convert/issues/124