### PR TITLE
Path resolution on Windows

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,8 @@ A simple and fast node.js module for converting office documents to different fo
 
 ## Dependency
 
-Please install libreoffice in /Applications (Mac), with your favorite package manager (Linux), or with the msi (Windows).
+Please install libreoffice in /Applications (Mac), with your favorite package manager (Linux), or with the msi (Windows)
+(On Windows, add `PROGRAMFILES` environment variable for Windows program files path to your local project)
 
 ## Usage example
 

--- a/index.js
+++ b/index.js
@@ -24,9 +24,12 @@ const convertWithOptions = (document, format, filter, options, callback) => {
                     break;
                 case 'win32': paths = [
                     ...paths,
-                    path.join(process.env['PROGRAMFILES(X86)'], 'LIBREO~1/program/soffice.exe'),
-                    path.join(process.env['PROGRAMFILES(X86)'], 'LibreOffice/program/soffice.exe'),
-                    path.join(process.env.PROGRAMFILES, 'LibreOffice/program/soffice.exe'),
+                    path.join(process.env['PROGRAMFILES(X86)'] || '', 'LIBREO~1/program/soffice.exe'),
+                    path.join(process.env['PROGRAMFILES(X86)'] || '', 'LibreOffice/program/soffice.exe'),
+                    path.join(process.env.PROGRAMFILES_X86 || '', 'LibreOffice/program/soffice.exe'),
+                    path.join(process.env.PROGRAMFILES || '', 'LibreOffice/program/soffice.exe'),  
+                    process.env.LIBRE_OFFICE_EXE || '',
+                     'C:/Program Files/CLibreOffice/program/soffice.exe'
                 ];
                     break;
                 default:


### PR DESCRIPTION
`PROGRAMFILES(X86)` is invalid `.env` variable, hence conversion fails on Windows. This fixes it, with extra sanity check and default path added on top.
