### PR TITLE
add support for `fileName` with extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ const convertWithOptions = (document, format, filter, options, callback) => {
             async.retry({
                 times: asyncOptions.times || 3,
                 interval: asyncOptions.interval || 200
-            }, (callback) => fs.readFile(path.join(tempDir.name, `${fileName}.${format.split(":")[0]}`), callback), callback)
+            }, (callback) => fs.readFile(path.join(tempDir.name, `${fileName.slice(0, fileName.length - path.extname(fileName).length)}.${format.split(":")[0]}`), callback), callback)
         ]
     }).then( (res) => {
         return callback(null, res.loadDestination);

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -2,7 +2,8 @@ var _jest = require('jest'),
     _fs = require('fs'),
     _path = require('path'),
     { exec } = require('child_process'),
-    convert = require('../index').convert;
+    convert = require('../index').convert
+    convertWithOptions = require('../index').convertWithOptions;
 
 describe('convert', () => {
     function expectHello(done) {
@@ -19,6 +20,12 @@ describe('convert', () => {
     it('should convert a word document to text',  (done) => {
         const docx = _fs.readFileSync(_path.join(__dirname, '/resources/hello.docx'));
         convert(docx, 'txt', undefined, expectHello(done));
+    });
+
+
+    it('should convert a word document to text with options', (done) => {
+        const docx = _fs.readFileSync(_path.join(__dirname, '/resources/hello.docx'));
+        convertWithOptions(docx, 'txt', undefined, { fileName: 'hello.docx' }, expectHello(done));
     });
 
 


### PR DESCRIPTION
This PR adds support for the `fileName` option containing an extension (e.g. `hello.docx`). This is useful for helping LibreOffice heuristics determine the type of input when it is ambiguous.

Currently, if `fileName` contains an extension, an error is passed to the callback: `ENOENT: no such file or directory, open '/var/folders/f5/nt6n0cwj5d1_0tgf8zwn8xsm0000gn/T/libreofficeConvert_-44609-XfkBGjSgBGiG/hello.docx.txt'`.