### PR TITLE
feat: improve error catching when running soffice

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,12 @@ const convertWithOptions = (document, format, filter, options, callback) => {
             args.push(tempDir.name);
             args.push(path.join(tempDir.name, fileName));
           
-            return execFile(results.soffice, args, execOptions, callback);
+            return execFile(results.soffice, args, execOptions, (err, stdout, stderr) => {
+                // warnings might also be emitted to stderr
+                if (stderr && stderr.toLowerCase().includes('error'))
+                    callback(new Error('Error calling soffice: ' + stderr));
+                else callback(err, stdout, stderr);
+            });
         }],
         loadDestination: ['convert', (results, callback) =>
             async.retry({

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -31,4 +31,14 @@ describe('convert', () => {
             convert(docx, 'txt', undefined, expectHello(done));
         }, 100);
     });
+
+    it('should fail when libreoffice encounters an error', (done) => {
+        // call with invalid document: a buffer starting with PNG header but data is missing
+        const badPng = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+        convert(badPng, 'txt', undefined, (err, result) => {
+            expect(err).toBeInstanceOf(Error);
+            expect(err.message).toMatch(/Error calling soffice:/);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Currently, if `soffice` fails to convert, the only error is that the library is unable to read the output file: `ENOENT: no such file or directory, open '/tmp/libreofficeConvert_-60085-nUSD021mMi5H/source.txt'`

This PR raises an error when libreoffice indicates an error occured. The error contains `stderr`, helping identify conversion issue source more easily.

This might break use cases where libreoffice indicated an error but conversion succeeds. Alternatively, we can simply log a warning.